### PR TITLE
Fix compression levels under 10

### DIFF
--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -152,7 +152,7 @@ fn compress_lookaround(
         CompressionLevel::Lookahead { quality } => quality,
     };
     const MAX_LOOKBACK: usize = 0x1000;
-    let lookback = (MAX_LOOKBACK / (10. / quality as f32)).floor() as usize;
+    let lookback = (MAX_LOOKBACK as f32 / (10. / quality as f32)).floor() as usize;
 
     // used to cache lookahead runs to put in the next packet,
     // since we need to write a head packet first

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -152,7 +152,7 @@ fn compress_lookaround(
         CompressionLevel::Lookahead { quality } => quality,
     };
     const MAX_LOOKBACK: usize = 0x1000;
-    let lookback = MAX_LOOKBACK / (quality as f32 / 10.).floor() as usize;
+    let lookback = (MAX_LOOKBACK / (10. / quality as f32)).floor() as usize;
 
     // used to cache lookahead runs to put in the next packet,
     // since we need to write a head packet first


### PR DESCRIPTION
This corrects the error that would lead to a divide by zero panic for compression quality less than 10, in order to close #3.